### PR TITLE
chore: disable caddy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,27 @@
 # Docker Compose v2 syntax - version field is optional
 
 services:
-  caddy:
-    image: caddy:2.8
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    environment:
-      - EMAIL=${EMAIL}
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./site:/srv:ro
-      - caddy_data:/data
-      - caddy_config:/config
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:80 || exit 1"]
-      interval: 60s
-      timeout: 5s
-      retries: 3
-    networks:
-      - pdfislemleri_network
-
+  #  caddy:
+  #    image: caddy:2.8
+  #    restart: unless-stopped
+  #    ports:
+  #      - "80:80"
+  #      - "443:443"
+  #    environment:
+  #      - EMAIL=${EMAIL}
+  #    volumes:
+  #      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+  #      - ./site:/srv:ro
+  #      - caddy_data:/data
+  #      - caddy_config:/config
+  #    healthcheck:
+  #      test: ["CMD-SHELL", "wget -qO- http://localhost:80 || exit 1"]
+  #      interval: 60s
+  #      timeout: 5s
+  #      retries: 3
+  #    networks:
+  #      - pdfislemleri_network
+  #
   api:
     container_name: pdfislemlericom-api
     build:
@@ -49,8 +49,8 @@ services:
       - "2000:2000"  # API'ye doğrudan erişim için
 
 volumes:
-  caddy_data:
-  caddy_config:
+  #  caddy_data:
+  #  caddy_config:
   api_temp:
 
 networks:


### PR DESCRIPTION
## Summary
- comment out caddy service and related volumes in docker-compose

## Testing
- `npm test` *(fails: Missing script "test")*
- `docker compose up -d --build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c7df1b1c408327a110e2e7e50e19c8